### PR TITLE
changed how the datetime of timeslots is displayed on show with strftime

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
 
   def show
     @user_skills = @user.user_skills.includes(:skill)
-    @reviews = current_user.reviews
+    @reviews = @user.reviews
   end
 
   def edit

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,7 +35,7 @@
           <% @user.timeslots.each do |timeslot| %>
             <% unless timeslot.ticket %>
               <li>
-                <%= timeslot.start_time %><%= link_to icon('fas', 'trash-alt'), timeslot_path(timeslot), method: :delete %>
+                <%= timeslot.start_time.strftime("%A, %d %B %Y, %H:%M") %><%= link_to icon('fas', 'trash-alt'), timeslot_path(timeslot), method: :delete %>
                 <%= link_to 'book this slot', new_timeslot_ticket_path(timeslot), class: 'btn btn-sm btn-dark' %>
               </li>
             <% end %>


### PR DESCRIPTION
Hey, guys! Minor tweaks here, I added a strftime method to the timeslot datetime on the user show page, so now we have a better display of the date.

![Captura de Tela 2020-11-25 às 11 40 14](https://user-images.githubusercontent.com/72105468/100242179-4432dc00-2f13-11eb-8586-d6c51b8cfd05.png)

Also did a minor change on the Users#Show, because I had current_user.reviews and I think it would be best to actually just have @user.reviews, because it will depend on the user params.
